### PR TITLE
Add weekly dependabot checks workflow

### DIFF
--- a/.github/workflows/dependabot-checks.yml
+++ b/.github/workflows/dependabot-checks.yml
@@ -1,0 +1,24 @@
+
+name: Weekly dependabot checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  evergreen:
+    name: evergreen
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Run evergreen action
+        uses: github/evergreen@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORGANIZATION: mziyut


### PR DESCRIPTION
This pull request adds a new workflow called "Weekly dependabot checks" that runs on a schedule every Saturday. The workflow uses the "evergreen" action from the GitHub Marketplace to perform dependabot checks. This will help ensure that our project's dependencies are up to date and secure.